### PR TITLE
Allow localized text in config fields

### DIFF
--- a/NeosModSettings/NeosModSettings.cs
+++ b/NeosModSettings/NeosModSettings.cs
@@ -442,24 +442,21 @@ namespace NeosModSettings
                     config.Set(typedKey, syncF.Value, "NeosModSettings variable change");
                 };
 
-                string varName = "";
-                if (String.IsNullOrWhiteSpace(key.Description))
+                bool nameAsKey = String.IsNullOrWhiteSpace(key.Description);
+                string localeText = nameAsKey ? key.Name : key.Description;
+                string format = "{0}";
+                if (Current.GetConfiguration().GetValue(Current.SHOW_NAMES) && !nameAsKey)
                 {
-                    varName = key.Name;
+                    format = $"<i><b>{key.Name}</i></b> - " + "{0}";
                 }
-                else
-                {
-                    if (Current.GetConfiguration().GetValue(Current.SHOW_NAMES))
-                        varName += $"<i><b>{key.Name}</i></b> - ";
-                    varName += key.Description;
-                }
-                if (key.InternalAccessOnly) varName = $"<color=#dec15b>{varName}</color>";
+
+                if (key.InternalAccessOnly) format = $"<color=#dec15b>{format}</color>";
 
                 RadiantUI_Constants.SetupDefaultStyle(ui);
 
-
                 ui.Style.TextAutoSizeMax = Current.GetConfiguration().GetValue(Current.ITEM_HEIGHT);
-                ui.HorizontalElementWithLabel<Component>(varName, 0.7f, () =>
+                var localized = new LocaleString(localeText, format, true, true, null);
+                ui.HorizontalElementWithLabel<Component>(localized, 0.7f, () =>
                 {// Using HorizontalElementWithLabel because it formats nicer than SyncMemberEditorBuilder with text
                     SyncMemberEditorBuilder.Build(dynvar.Value, null, dynvar.GetSyncMemberFieldInfo(4), ui); // Using null for name makes it skip generating text
                     // Can't recolor fields because PrimitiveMemeberEditor sets the colors on changes


### PR DESCRIPTION
Enables mod authors to use the application's existing localization keys in place of static text.
The format for locale keys is very distinct and requires text to be matched exactly - so there's no real risk of accidental parsing.

This would be a helpful change for authors looking to globalize their mod configuration.

## Resources
- [Localization definitions for NeosVR](https://github.com/Neos-Metaverse/NeosLocale)