### PR TITLE
Fix logspam related to NaN inequality

### DIFF
--- a/NeosModSettings/NeosModSettings.cs
+++ b/NeosModSettings/NeosModSettings.cs
@@ -422,7 +422,8 @@ namespace NeosModSettings
                     var typedKey = key as ModConfigurationKey<T>;
 
                     bool isSet = config.TryGetValue(typedKey, out T configValue);
-                    if (isSet && Object.Equals(configValue, syncF.Value)) return; // Skip if new value is equal to old
+                    bool wasModified = !configValue.Equals(syncF.Value) && syncF.Value.Equals(syncF.Value);
+                    if (isSet && !wasModified) return; // Skip if new value is unmodified or is logically inconsistent (self != self)
 
                     if (!key.Validate(syncF.Value))
                     { // Fallback if validation fails


### PR DESCRIPTION
There seems to be a quirk with DynamicValueVariable objects where OnValueChange is fired anytime its value is fetched and is not equal to itself.

This behaviour results in logspam if the selected mod has internal fields relying on NaN as a starting value. This specifically affects BaseX vector and matrix structs with NaN components. The resulting logspam slows the user's framerate until another mod tab gains focus.

## Snippet from log
```
Cannot modify disposed elements! Hierachy: 
Element: ID2880400, Type: FrooxEngine.Sync`1[BaseX.float2x2], World: null, IsRemoved: True, Name: , Disposed: True, LastVersion: 0, LastConfirmedTime: 0, LastHostVersion: 0, LastModifyingUser: 
```

These introduced changes address the issue through ignoring the new value if not equal to itself. This fixes the logspam through preventing SyncField values from being set in an invalid state.

For eldritch reasons beyond human comprehension, I made sure to allow the value to be initialized to a NaN state if necessary. Praise the NaN and its mathematical beauty.